### PR TITLE
Add JUnit5 as Maven Dependency + Init Gitlab CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.settings/
 /target/
+.idea
+*.iml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+image: maven:3.5.4-jdk-10
+stages:
+- build
+- test
+- package
+
+maven:build:
+  stage: build
+  environment: staging
+  script:
+  - "mvn clean compile"
+  artifacts:
+    when: on_success
+    expire_in: 1 day
+    paths:
+    - target/
+
+maven:test:
+  stage: test
+  environment: staging
+  dependencies:
+    - maven:build
+  script: "mvn clean test"
+  artifacts:
+    when: on_success
+    expire_in: 1 day
+    paths:
+    - target/
+
+
+maven:package:
+  stage: package
+  environment: staging
+  dependencies:
+    - maven:test
+  script: "mvn package"
+  artifacts:
+    when: on_success
+    expire_in: 1 day
+    paths:
+    - target/

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,37 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 			<version>1.0.3</version>
 		</dependency>
 		
-		<!-- Add a dependency to JUnit for unit tests --> 
-		
+		<!-- Add a dependency to JUnit for unit tests -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-runner</artifactId>
+			<version>1.1.0</version>
+			<scope>test</scope>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/fr.inra.ijpb/MorphoLibJ_ -->
 		<dependency>
     		<groupId>fr.inra.ijpb</groupId>
@@ -69,6 +98,27 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 				<directory>${project.build.testSourceDirectory}</directory>
 			</testResource>
 		</testResources>
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.platform</groupId>
+						<artifactId>junit-platform-surefire-provider</artifactId>
+						<version>1.1.0</version>
+					</dependency>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>5.1.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+
 	</build>
 
 	<developers>
@@ -84,6 +134,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 			<timezone>+1</timezone>
 		</developer>
 	</developers>
+
 
 	<repositories>
 		<!-- NB: for project parent -->

--- a/src/test/java/JUnit5ExampleTest.java
+++ b/src/test/java/JUnit5ExampleTest.java
@@ -1,0 +1,9 @@
+import org.junit.jupiter.api.Test;
+
+class JUnit5ExampleTest {
+
+    @Test
+    void justAnExample() {
+        System.out.println("This test method should be run");
+    }
+}


### PR DESCRIPTION
- To allow the TDD for the next improvements, I propose the usage of JUnit5 Framework.
- The current CI is missing. Before to integrate a Travis solution, You can find here a first integration of a GitlabCI, with Maven Build, Package and Test steps 