### PR TITLE
Add Javadoc support in Pom.XML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,17 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
 				<directory>${project.build.testSourceDirectory}</directory>
 			</testResource>
 		</testResources>
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.1</version>
+				<configuration>
+					<additionalJOption>-Xdoclint:none</additionalJOption>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 
 	<developers>


### PR DESCRIPTION
Add the Javadoc plugin in the Pom.XML, with each Warning as Warning during the task running (to make progressive the doc improvement).